### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This task is available immediately (`availableDate` defaults to now) and will re
 
 ## Requirements
 
-ARC, iOS 6+, and [FMDB](https://github.com/ccgus/fmdb) by Gus Mueller. FMDB will be imported automatically by Cocoapods. Don't worry; it's super-small.
+ARC, iOS 6+, and [FMDB](https://github.com/ccgus/fmdb) by Gus Mueller. FMDB will be imported automatically by CocoaPods. Don't worry; it's super-small.
 
 ## Feedback
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
